### PR TITLE
Add aggregation for component execution

### DIFF
--- a/logstash/pipeline.conf
+++ b/logstash/pipeline.conf
@@ -138,21 +138,36 @@ filter {
       }
     }
 
-    if [log_message] =~ "elapsed" {
-      grok {
-        patterns_dir => "./patterns"
-        match => { "log_message" => "%{SERVICE_DUR}" }
-        remove_tag => ["_grokparsefailure"]
-        add_tag => ["comp_duration"]
-      }
-    }
-
-    if [log_message] =~ "Executing" {
+    if [log_message] =~ "Executing component" {
       grok {
         patterns_dir => "./patterns"
         match => { "log_message" => "%{EXEC_COMP}" }
-        remove_tag => ["_grokparsefailure"]
         add_tag => ["comp_exec"]
+      }
+
+      # Create new entry that combines component name with durations
+      aggregate {
+        task_id => "%{vm}%{pid}%{service_request}"
+        code => "map['componentName'] = event.get('componentName')"
+        map_action => "create"
+      }
+    }
+
+    if [log_message] =~ "elapsed time=" {
+      grok {
+        patterns_dir => "./patterns"
+        match => { "log_message" => "%{SERVICE_DUR}" }
+        add_tag => ["comp_duration"]
+      }
+
+      aggregate {
+        task_id => "%{vm}%{pid}%{service_request}"
+        code => "event.set('componentName', map['componentName'])"
+        map_action => "update"
+        end_of_task => true
+        timeout => 600
+        push_map_as_event_on_timeout => true
+        add_tag => ["duration"]
       }
     }
 


### PR DESCRIPTION
Aggregate the APPSRV.log component execution name with the duration. The `componentName` field is added to the corresponding log entry with the elapsed duration. Now you can create component duration visualizations using the new log line.